### PR TITLE
Improved Logging Around unable to load access token

### DIFF
--- a/src/Rest/OAuthRestClient.php
+++ b/src/Rest/OAuthRestClient.php
@@ -183,7 +183,8 @@ final class OAuthRestClient implements RestClientInterface
     private function getOAuthAccessTokenFromResponse(ResponseInterface $response): OAuthAccessToken
     {
         if ($response->getStatusCode() !== 200) {
-            throw OAuthRestClientException::unableToLoadAccessToken();
+            $message = '(' . $response->getStatusCode() . ') ' . $response->getBody()->__toString();
+            throw OAuthRestClientException::unableToLoadAccessToken($message);
         }
 
         $response = json_decode($response->getBody()->__toString(), true);

--- a/src/Rest/OAuthRestClientException.php
+++ b/src/Rest/OAuthRestClientException.php
@@ -5,8 +5,14 @@ use Exception;
 
 class OAuthRestClientException extends Exception
 {
-    public static function unableToLoadAccessToken()
+    public static function unableToLoadAccessToken(?string $message = null)
     {
-        return new self('Unable to load access token');
+        $errorMessage = 'Unable to load access token';
+        
+        if ($message) {
+            $errorMessage . ': ' . $message;
+        }
+
+        return new self($errorMessage);
     }
 }


### PR DESCRIPTION
- If a non 200 status code is thrown, we include the status code and message in the exception thrown